### PR TITLE
Add CRUD functionality for transactions

### DIFF
--- a/src/main/java/bank/backend/bms/controllers/TransactionController.java
+++ b/src/main/java/bank/backend/bms/controllers/TransactionController.java
@@ -1,0 +1,54 @@
+package bank.backend.bms.controllers;
+
+import bank.backend.bms.models.Transaction;
+import bank.backend.bms.services.TransactionService;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
+
+@RestController
+@RequestMapping("/api/transactions")
+public class TransactionController {
+
+    @Autowired
+    private TransactionService transactionService;
+
+    
+    @PostMapping
+    public ResponseEntity<Transaction> createTransaction(@RequestBody Transaction transaction) {
+        Transaction createdTransaction = transactionService.createTransaction(transaction);
+        return new ResponseEntity<>(createdTransaction, HttpStatus.CREATED);
+    }
+
+    @GetMapping
+    public ResponseEntity<List<Transaction>> getAllTransactions() {
+        List<Transaction> transactions = transactionService.getAllTransactions();
+        return new ResponseEntity<>(transactions, HttpStatus.OK);
+    }
+
+    @GetMapping("/{id}")
+    public ResponseEntity<Transaction> getTransactionById(@PathVariable Long id) {
+        Transaction transaction = transactionService.getTransactionById(id);
+        return new ResponseEntity<>(transaction, HttpStatus.OK);
+    }
+
+    
+    @PutMapping("/{id}")
+    public ResponseEntity<Transaction> updateTransaction(
+            @PathVariable Long id,
+            @RequestBody Transaction updatedTransaction) {
+        Transaction transaction = transactionService.updateTransaction(id, updatedTransaction);
+        return new ResponseEntity<>(transaction, HttpStatus.OK);
+    }
+
+    
+    @DeleteMapping("/{id}")
+    public ResponseEntity<Void> deleteTransaction(@PathVariable Long id) {
+        transactionService.deleteTransaction(id);
+        return new ResponseEntity<>(HttpStatus.NO_CONTENT);
+    }
+
+}

--- a/src/main/java/bank/backend/bms/models/Transaction.java
+++ b/src/main/java/bank/backend/bms/models/Transaction.java
@@ -1,0 +1,47 @@
+package bank.backend.bms.models;
+
+import java.time.LocalDateTime;
+
+import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Null;
+import jakarta.validation.constraints.Positive;
+import lombok.Data;
+
+@Data
+@Entity
+public class Transaction {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Enumerated(EnumType.STRING)
+    @NotNull(message = "Transaction type is required")
+    private TransactionEnums.TransactionType transactionType;
+
+    @Null
+    // @NotNull(message = "Source account is required")
+    private Long accountIdFrom;
+
+    @Null
+    private Long accountIdTo;
+
+    @NotNull(message = "Amount is required")
+    @Positive(message = "Amount must be greater than zero")
+    private double amount;
+
+    @Enumerated(EnumType.STRING)
+    @NotNull(message = "Transaction Status is required")
+    private TransactionEnums.TransactionStatus transactionStatus;
+
+    @NotNull(message = "Transaction date is required")
+    // @PastOrPresent(message="Transaction date must not be in the future")
+    private LocalDateTime transactionDate;
+
+
+}

--- a/src/main/java/bank/backend/bms/models/TransactionEnums.java
+++ b/src/main/java/bank/backend/bms/models/TransactionEnums.java
@@ -1,0 +1,14 @@
+package bank.backend.bms.models;
+
+public class TransactionEnums {
+    public enum TransactionType{
+        DEPOSIT,
+        WITHDRAWL,
+        TRANSFER
+    }
+    public enum TransactionStatus{
+        PENDING,
+        SUCCESS,
+        FAILED
+    }
+}

--- a/src/main/java/bank/backend/bms/repositories/TransactionRepository.java
+++ b/src/main/java/bank/backend/bms/repositories/TransactionRepository.java
@@ -1,0 +1,9 @@
+package bank.backend.bms.repositories;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+import bank.backend.bms.models.Transaction;
+
+@Repository
+public interface  TransactionRepository extends JpaRepository<Transaction, Long>{}

--- a/src/main/java/bank/backend/bms/services/TransactionService.java
+++ b/src/main/java/bank/backend/bms/services/TransactionService.java
@@ -1,0 +1,58 @@
+package bank.backend.bms.services;
+
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.Optional;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Service;
+
+import bank.backend.bms.models.Transaction;
+import bank.backend.bms.models.TransactionEnums.TransactionStatus;
+import bank.backend.bms.repositories.TransactionRepository;
+
+@Service
+public class TransactionService {
+
+    @Autowired
+    private TransactionRepository transactionRepository;
+
+    public List<Transaction> getAllTransactions(){
+        return transactionRepository.findAll();
+    }
+
+    public Transaction getTransactionById(Long id) {
+        return transactionRepository.findById(id)
+                .orElseThrow(() -> new RuntimeException("Transaction not found with ID: " + id));
+    }
+    
+    public Transaction createTransaction(Transaction transaction){
+        if(transaction.getTransactionStatus() == null){
+            transaction.setTransactionStatus(TransactionStatus.PENDING);
+        }
+        if(transaction.getTransactionDate()== null){
+            transaction.setTransactionDate(LocalDateTime.now());
+        }
+        return transactionRepository.save(transaction);
+    }
+
+    public Transaction updateTransaction(Long id, Transaction updatedTransaction) {
+        Optional<Transaction> optionalTransaction = transactionRepository.findById(id);
+
+        if (optionalTransaction.isEmpty()) {
+            throw new RuntimeException("Transaction not found with ID: " + id);
+        }
+
+        Transaction existingTransaction = optionalTransaction.get();
+        existingTransaction.setTransactionStatus(updatedTransaction.getTransactionStatus());
+        return transactionRepository.save(existingTransaction);
+    }
+
+    public void deleteTransaction(Long id) {
+        if (!transactionRepository.existsById(id)) {
+            throw new RuntimeException("Transaction not found with ID: " + id);
+        }
+        transactionRepository.deleteById(id);
+    }
+
+}

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -2,7 +2,7 @@ spring.application.name=BMS
 # Database connection
 spring.datasource.url=jdbc:mysql://localhost:3306/bms_db
 spring.datasource.username=root
-spring.datasource.password=root
+spring.datasource.password=
 spring.datasource.driver-class-name=com.mysql.cj.jdbc.Driver
 
 # Hibernate settings


### PR DESCRIPTION
This pull request adds CRUD functionality for transactions in the system. The implementation includes:

- Creating, retrieving, updating, and deleting transactions.
- Validation of key fields like `transactionType`, `transactionAmount`, `transactionDate`, and `transactionStatus`.

**Note:**
*The account number functionality has been intentionally ignored in this implementation because the Account table is still in progress.*

Use Postman or any API testing tool to send requests to the following endpoints:
`POST /api/transactions` to create a new transaction.
`GET /api/transactions/{id}` to retrieve a transaction.
`PUT /api/transactions/{id}` to update a transaction.
`DELETE /api/transactions/{id}` to delete a transaction.

**Additional Notes:**
*This is a foundational implementation of transaction management. Future updates will include linking transactions to accounts once the Account table is complete.*